### PR TITLE
Allow passing a scroll physics parameter

### DIFF
--- a/lib/markdown_widget.dart
+++ b/lib/markdown_widget.dart
@@ -38,6 +38,9 @@ class MarkdownWidget extends StatefulWidget {
   ///set the desired scroll physics for the markdown item list
   final ScrollPhysics physics;
 
+  ///set shrinkWrap to obtained [ListView] (only available when [controller] is null)
+  final bool shrinkWrap;
+
   const MarkdownWidget({
     Key key,
     @required this.data,
@@ -49,6 +52,7 @@ class MarkdownWidget extends StatefulWidget {
     this.clearPositionWhenUpdate = false,
     this.delayLoadDuration,
     this.physics,
+    this.shrinkWrap = false,
   }) : super(key: key);
 
   @override
@@ -140,7 +144,7 @@ class _MarkdownWidgetState extends State<MarkdownWidget> {
   Widget buildMarkdownWidget() {
     return widget.controller == null
         ? ListView.builder(
-            shrinkWrap: widget.physics != null,
+            shrinkWrap: widget.shrinkWrap,
             physics: widget.physics,
             itemBuilder: (ctx, index) => widgets[index],
             itemCount: widgets.length,

--- a/lib/markdown_widget.dart
+++ b/lib/markdown_widget.dart
@@ -35,6 +35,9 @@ class MarkdownWidget extends StatefulWidget {
   ///delay refresh when initial markdown widget
   final Duration delayLoadDuration;
 
+  ///set the desired scroll physics for the markdown item list
+  final ScrollPhysics physics;
+
   const MarkdownWidget({
     Key key,
     @required this.data,
@@ -45,6 +48,7 @@ class MarkdownWidget extends StatefulWidget {
     this.loadingWidget,
     this.clearPositionWhenUpdate = false,
     this.delayLoadDuration,
+    this.physics,
   }) : super(key: key);
 
   @override
@@ -136,10 +140,13 @@ class _MarkdownWidgetState extends State<MarkdownWidget> {
   Widget buildMarkdownWidget() {
     return widget.controller == null
         ? ListView.builder(
+            shrinkWrap: widget.physics != null,
+            physics: widget.physics,
             itemBuilder: (ctx, index) => widgets[index],
             itemCount: widgets.length,
           )
         : ScrollablePositionedList.builder(
+            physics: widget.physics,
             itemCount: widgets.length,
             itemBuilder: (context, index) => widgets[index],
             itemScrollController: widget.controller.scrollController,


### PR DESCRIPTION
Hi,

I have a MarkdownWidget inside a scrollable ListView widget with other widgets. I want to control the scroll from the parent ListView. I was not able to do so with the actual implementation.

Do you know if I can get that desired behavior without modifying MarkdownWidget?

In case it is not possible I did this fast PR that works for me

Thank you!