### PR TITLE
Make toc list public in TocController

### DIFF
--- a/lib/markdown_toc.dart
+++ b/lib/markdown_toc.dart
@@ -118,8 +118,10 @@ class TocController extends ChangeNotifier {
   TocController({this.initialIndex = 0, this.isInitialIndexForTitle = true});
 
   Toc _currentToc;
-
   LinkedHashMap<int, Toc> _tocList;
+
+  Toc get currentToc => _currentToc;
+  Map<int, Toc> get tocList => _tocList;
 
   bool setToc(Toc toc) {
     if (this._currentToc == toc) return false;


### PR DESCRIPTION
I wanted to create custom Table of Content widget, but the list of toc items was private. So I think it is reasonable to expose public getter for list of items and current item.