### PR TITLE
Add ability to create custom Table of Content widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+#### [1.2.1+1] - expose `tocList` and `currentToc` properties in `TocController` (thanks to @[jarekb123](https://github.com/jarekb123))
+
 #### [1.2.1] -  fix issue [#25](https://github.com/asjqkkkk/markdown_widget/issues/25) [#28](https://github.com/asjqkkkk/markdown_widget/issues/28) [#29](https://github.com/asjqkkkk/markdown_widget/issues/29) [#32](https://github.com/asjqkkkk/markdown_widget/issues/32)
 
 #### [1.2.0] -  add `TextConfig` to set `TextAlign` and `TextDirection`,solve issue [#21](https://github.com/asjqkkkk/markdown_widget/issues/21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#### [1.2.1+1] - expose `tocList` and `currentToc` properties in `TocController` (thanks to @[jarekb123](https://github.com/jarekb123))
+#### [1.2.1+1] - expose `tocList` and `currentToc` properties in `TocController` (thanks to @[jarekb123](https://github.com/jarekb123)). It adds ability to create custom Table of Content widgets
 
 #### [1.2.1] -  fix issue [#25](https://github.com/asjqkkkk/markdown_widget/issues/25) [#28](https://github.com/asjqkkkk/markdown_widget/issues/28) [#29](https://github.com/asjqkkkk/markdown_widget/issues/29) [#32](https://github.com/asjqkkkk/markdown_widget/issues/32)
 

--- a/lib/markdown_toc.dart
+++ b/lib/markdown_toc.dart
@@ -121,6 +121,11 @@ class TocController extends ChangeNotifier {
 
   LinkedHashMap<int, Toc> _tocList;
 
+  Toc get currentToc => _currentToc;
+
+  /// List of toc (table of content) items
+  Map<int, Toc> get tocList => _tocList;
+
   bool setToc(Toc toc) {
     if (this._currentToc == toc) return false;
     this._currentToc = toc;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: markdown_widget
 description: A new markdown package. It supports TOC function, HTML video and img tag，and it works well on both the web and mobile
-version: 1.2.1
+version: 1.2.1+1
 verified publisher:
   - agedchen@gmail.com
 homepage: https://github.com/asjqkkkk/markdown_widget


### PR DESCRIPTION
I wanted to create custom Table of Content widget, but the list of toc items was private. So I think it is reasonable to expose public getter for list of items and current item.