### PR TITLE
Fix Long Code

### DIFF
--- a/lib/tags/pre.dart
+++ b/lib/tags/pre.dart
@@ -163,6 +163,8 @@ class HighlightView extends StatelessWidget {
       ),
       textAlign: StyleConfig().preConfig?.textAlign,
       textDirection: StyleConfig().preConfig?.textDirection,
+      scrollPhysics: NeverScrollableScrollPhysics(),
+
     );
   }
 }


### PR DESCRIPTION
当插入长代码(代码块超过屏幕高度时),SelectableText会触发滚动机制从而影响整个页面滚动.