### PR TITLE
fix LinkNode child no styles

### DIFF
--- a/lib/widget/blocks/leaf/link.dart
+++ b/lib/widget/blocks/leaf/link.dart
@@ -20,15 +20,17 @@ class LinkNode extends ElementNode {
   @override
   InlineSpan build() {
     final url = attributes['href'] ?? '';
-    return TextSpan(
-      children: List.generate(children.length, (index) {
-        final child = children[index];
-        return _toLinkInlineSpan(
+    return TextSpan(children: [
+      for (final child in children)
+        _toLinkInlineSpan(
           child.build(),
           () => _onLinkTap(linkConfig, url),
-        );
-      }),
-    );
+        ),
+      if (children.isNotEmpty)
+        // FIXME: this is a workaround, maybe need fixed by flutter framework.
+        // add a space to avoid the space area of line end can be tapped.
+        TextSpan(text: ' '),
+    ]);
   }
 
   void _onLinkTap(LinkConfig linkConfig, String url) {
@@ -67,6 +69,11 @@ InlineSpan _toLinkInlineSpan(InlineSpan span, VoidCallback onTap) {
       children: span.children?.map((e) => _toLinkInlineSpan(e, onTap)).toList(),
       style: span.style,
       recognizer: TapGestureRecognizer()..onTap = onTap,
+      onEnter: span.onEnter,
+      onExit: span.onExit,
+      semanticsLabel: span.semanticsLabel,
+      locale: span.locale,
+      spellOut: span.spellOut,
     );
   } else if (span is WidgetSpan) {
     span = WidgetSpan(

--- a/lib/widget/blocks/leaf/link.dart
+++ b/lib/widget/blocks/leaf/link.dart
@@ -20,63 +20,15 @@ class LinkNode extends ElementNode {
   @override
   InlineSpan build() {
     final url = attributes['href'] ?? '';
-    final recognizer = TapGestureRecognizer()
-      ..onTap = () {
-        _onLinkTap(linkConfig, url);
-      };
-    final spans =
-        List.generate(children.length, (index) => children[index].build());
-    final List<InlineSpan> formatSpans = [];
-    _formatChildren(spans, formatSpans);
-    final List<InlineSpan> result = [];
-    String text = '';
-    for (final span in formatSpans) {
-      if (span is WidgetSpan) {
-        _addTextSpan(text, result, recognizer);
-        _addWidgetSpan(result, span, url);
-        text = '';
-      } else if (span is TextSpan) {
-        text += span.text ?? '';
-      }
-    }
-    if (text.isNotEmpty) _addTextSpan(text, result, recognizer, isLast: true);
-    return TextSpan(children: result);
-  }
-
-  ///if text is not empty, add textSpan to [result]
-  void _addTextSpan(
-      String text, List<InlineSpan> result, TapGestureRecognizer recognizer,
-      {bool isLast = false}) {
-    if (text.isNotEmpty)
-      result.add(TextSpan(text: text, style: style, recognizer: recognizer));
-    if (isLast) result.add(TextSpan(text: ' '));
-  }
-
-  ///add widgetSpan to [result]
-  void _addWidgetSpan(List<InlineSpan> result, WidgetSpan span, String url) {
-    result.add(WidgetSpan(
-        child: InkWell(
-          child: span.child,
-          onTap: () => _onLinkTap(linkConfig, url),
-        ),
-        alignment: span.alignment,
-        baseline: span.baseline,
-        style: span.style?.merge(style) ?? style));
-  }
-
-  ///visit children, and put them in the [result]
-  void _formatChildren(List<InlineSpan> spans, List<InlineSpan> result) {
-    for (final span in spans) {
-      if (span is! TextSpan) {
-        result.add(span);
-        return;
-      }
-      if (span.children == null || (span.children?.isEmpty ?? true)) {
-        result.add(span);
-        return;
-      }
-      _formatChildren(span.children!, result);
-    }
+    return TextSpan(
+      children: List.generate(children.length, (index) {
+        final child = children[index];
+        return _toLinkInlineSpan(
+          child.build(),
+          () => _onLinkTap(linkConfig, url),
+        );
+      }),
+    );
   }
 
   void _onLinkTap(LinkConfig linkConfig, String url) {
@@ -105,4 +57,27 @@ class LinkConfig implements LeafConfig {
   @nonVirtual
   @override
   String get tag => MarkdownTag.a.name;
+}
+
+// add a tap gesture recognizer to the span.
+InlineSpan _toLinkInlineSpan(InlineSpan span, VoidCallback onTap) {
+  if (span is TextSpan) {
+    span = TextSpan(
+      text: span.text,
+      children: span.children?.map((e) => _toLinkInlineSpan(e, onTap)).toList(),
+      style: span.style,
+      recognizer: TapGestureRecognizer()..onTap = onTap,
+    );
+  } else if (span is WidgetSpan) {
+    span = WidgetSpan(
+      child: InkWell(
+        child: span.child,
+        onTap: onTap,
+      ),
+      alignment: span.alignment,
+      baseline: span.baseline,
+      style: span.style,
+    );
+  }
+  return span;
 }


### PR DESCRIPTION

this fix relate to https://github.com/asjqkkkk/markdown_widget/pull/84. It is found that the dev branch has fixed the problem that some link nodes cannot be clicked, but the font style will be lost.

This fix can still make the link node click normally without affecting the font style.

example:

```
[**build**](https://github.com/MixinNetwork/flutter-app/actions/runs/4289468148/jobs/7472536663)
[**#1000 _Bump markdown_widget_from_ 1.3.0+2 to 2.0.0+1**](https://github.com/MixinNetwork/flutter-app/pull/1000)
```

before:

<img width="805" alt="image" src="https://user-images.githubusercontent.com/17426470/221766621-4be47002-c58d-4f63-aa13-0fb72f6bcc9d.png">


now:
<img width="833" alt="image" src="https://user-images.githubusercontent.com/17426470/221766505-83bbaac2-9916-4119-9263-e811bda89cc1.png">
