### PR TITLE
Fix: list items and header config

### DIFF
--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -1,7 +1,5 @@
-import 'package:example/pages/router.dart';
 import 'package:example/widget/menu.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_redux/flutter_redux.dart';
 import 'package:go_router/go_router.dart';
 import '../platform_detector/platform_detector.dart';
 import '../state/root_state.dart';

--- a/lib/config/configs.dart
+++ b/lib/config/configs.dart
@@ -104,17 +104,17 @@ enum MarkdownTag {
 class MarkdownConfig {
   HrConfig get hr => _getConfig<HrConfig>(MarkdownTag.hr, const HrConfig());
 
-  H1Config get h1 => _getConfig<H1Config>(MarkdownTag.h1, const H1Config());
+  HeadingConfig get h1 => _getConfig<HeadingConfig>(MarkdownTag.h1, const H1Config());
 
-  H2Config get h2 => _getConfig<H2Config>(MarkdownTag.h2, const H2Config());
+  HeadingConfig get h2 => _getConfig<HeadingConfig>(MarkdownTag.h2, const H2Config());
 
-  H3Config get h3 => _getConfig<H3Config>(MarkdownTag.h3, const H3Config());
+  HeadingConfig get h3 => _getConfig<HeadingConfig>(MarkdownTag.h3, const H3Config());
 
-  H4Config get h4 => _getConfig<H4Config>(MarkdownTag.h4, const H4Config());
+  HeadingConfig get h4 => _getConfig<HeadingConfig>(MarkdownTag.h4, const H4Config());
 
-  H5Config get h5 => _getConfig<H5Config>(MarkdownTag.h5, const H5Config());
+  HeadingConfig get h5 => _getConfig<HeadingConfig>(MarkdownTag.h5, const H5Config());
 
-  H6Config get h6 => _getConfig<H6Config>(MarkdownTag.h6, const H6Config());
+  HeadingConfig get h6 => _getConfig<HeadingConfig>(MarkdownTag.h6, const H6Config());
 
   PreConfig get pre =>
       _getConfig<PreConfig>(MarkdownTag.pre, const PreConfig());

--- a/lib/widget/blocks/container/list.dart
+++ b/lib/widget/blocks/container/list.dart
@@ -97,6 +97,7 @@ class ListNode extends ElementNode {
       child: Padding(
         padding: EdgeInsets.only(bottom: marginBottom),
         child: Row(
+          mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             SizedBox(


### PR DESCRIPTION
Fix the following issues:
- list item (from `ListNode`) takes all available horizontal space
- header configs can't be overriden by extending the HeadingConfig