### PR TITLE
Chor: make ListNode extendable

### DIFF
--- a/lib/widget/blocks/container/list.dart
+++ b/lib/widget/blocks/container/list.dart
@@ -24,7 +24,7 @@ class UlOrOLNode extends ElementNode {
   void accept(SpanNode? node) {
     super.accept(node);
     if (node != null && node is ListNode) {
-      node._index = start;
+      node.index = start;
       start++;
     }
   }
@@ -61,7 +61,7 @@ class ListNode extends ElementNode {
 
   ListNode(this.config);
 
-  int _index = 0;
+  int index = 0;
 
   bool get isOrdered {
     final p = parent;
@@ -89,8 +89,8 @@ class ListNode extends ElementNode {
     if (isCheckbox) {
       marker = ProxyRichText(children.removeAt(0).build());
     } else {
-      marker = config.li.marker?.call(isOrdered, depth, _index) ??
-          getDefaultMarker(isOrdered, depth, parentStyle?.color, _index,
+      marker = config.li.marker?.call(isOrdered, depth, index) ??
+          getDefaultMarker(isOrdered, depth, parentStyle?.color, index,
               parentStyleHeight / 2, config);
     }
     return WidgetSpan(
@@ -104,7 +104,7 @@ class ListNode extends ElementNode {
               width: space,
               child: marker,
             ),
-            Expanded(child: ProxyRichText(childrenSpan)),
+            Flexible(child: ProxyRichText(childrenSpan)),
           ],
         ),
       ),

--- a/lib/widget/blocks/container/list.dart
+++ b/lib/widget/blocks/container/list.dart
@@ -24,7 +24,7 @@ class UlOrOLNode extends ElementNode {
   void accept(SpanNode? node) {
     super.accept(node);
     if (node != null && node is ListNode) {
-      node.index = start;
+      node._index = start;
       start++;
     }
   }
@@ -61,7 +61,8 @@ class ListNode extends ElementNode {
 
   ListNode(this.config);
 
-  int index = 0;
+  int _index = 0;
+  int get index => _index;
 
   bool get isOrdered {
     final p = parent;

--- a/lib/widget/blocks/container/list.dart
+++ b/lib/widget/blocks/container/list.dart
@@ -105,7 +105,21 @@ class ListNode extends ElementNode {
               width: space,
               child: marker,
             ),
-            Flexible(child: ProxyRichText(childrenSpan)),
+            Flexible(
+              child: ProxyRichText(
+                TextSpan(
+                  children: [
+                    if (children.isNotEmpty) children.first.build(),
+                    for (final child in children.skip(1)) ...[
+                      // Introducing a new line before the next list item.
+                      // Otherwise, it might be rendered on the same line, disrupting the layout.
+                      if (child is UlOrOLNode) const TextSpan(text: '\n'),
+                      child.build(),
+                    ],
+                  ],
+                ),
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
Hello,

Currently, inheriting from `ListNode` is not possible due to its private field `_index`, which the build method relies on.

Why do I want to extend `ListNode`? The motivation behind this is that it utilizes the `Row` with `Expanded` widgets, causing it to occupy all available horizontal space. I aim to rectify this behavior with the following code:

```dart
Row(
  mainAxisSize: MainAxisSize.min,
  crossAxisAlignment: CrossAxisAlignment.start,
  children: [
    SizedBox(
      width: space,
      child: marker,
    ),
    Flexible(
      child: Text.rich(
        TextSpan(
          children: [
            if (children.isNotEmpty) children.first.build(),
            for (final child in children.skip(1)) ...[
              // Introducing a new line before the next list item.
              // Otherwise, it might be rendered on the same line, disrupting the layout.
              if (child is UlOrOLNode) const TextSpan(text: '\n'),
              child.build(),
            ],
          ],
        ),
      ),
    ),
  ],
)
```

This code addresses the issue as follows:
- It uses `Flexible` instead of `Expanded`.
- By avoiding `Expanded`, sublists won't be rendered on new lines, so I've added the `\n` text span before them.

By the way, should I create a pull request with the above fix? Or perhaps there's an alternative solution? What are your thoughts? 🙂