### PR TITLE
Fix: block quote layout issue

### DIFF
--- a/lib/widget/blocks/container/blockquote.dart
+++ b/lib/widget/blocks/container/blockquote.dart
@@ -2,9 +2,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../../config/configs.dart';
-import '../../proxy_rich_text.dart';
 import '../../span_node.dart';
 import '../../widget_visitor.dart';
+import '../leaf/paragraph.dart';
 
 ///Tag: [MarkdownTag.blockquote]
 ///
@@ -17,18 +17,41 @@ class BlockquoteNode extends ElementNode {
 
   @override
   InlineSpan build() {
+    final List<Widget> widgets = [];
+    for (int i = 0; i < children.length; i++) {
+      final span = children[i];
+      final textSpan = span.build();
+      final richText =
+          visitor.richTextBuilder?.call(textSpan) ?? Text.rich(textSpan);
+      final padding = span is ParagraphNode &&
+              i + 1 < children.length &&
+              children[i + 1] is ParagraphNode
+          ? const EdgeInsets.only(bottom: 16)
+          : null;
+      widgets.add(padding == null
+          ? richText
+          : Padding(padding: padding, child: richText));
+    }
+
     return WidgetSpan(
-        child: Container(
-      width: double.infinity,
-      decoration: BoxDecoration(
+      child: Container(
+        width: double.infinity,
+        decoration: BoxDecoration(
           border: Border(
-        left: BorderSide(color: config.sideColor, width: config.sideWith),
-      )),
-      padding: config.padding,
-      margin: config.margin,
-      child:
-          ProxyRichText(childrenSpan, richTextBuilder: visitor.richTextBuilder),
-    ));
+            left: BorderSide(color: config.sideColor, width: config.sideWith),
+          ),
+        ),
+        padding: config.padding,
+        margin: config.margin,
+        child: ListView.builder(
+          padding: EdgeInsets.zero,
+          shrinkWrap: true,
+          physics: NeverScrollableScrollPhysics(),
+          itemCount: widgets.length,
+          itemBuilder: (context, index) => widgets[index],
+        ),
+      ),
+    );
   }
 
   @override


### PR DESCRIPTION
fix #200 

Example:
```
> 1
> 2
> 
> 3
```

Before:
![image](https://github.com/user-attachments/assets/ee229f74-1f94-42eb-be8c-0444803591ac)

After:
![image](https://github.com/user-attachments/assets/e4d7fab7-fe96-4a9c-82b0-6abd7d1af570)