### PR TITLE
feat: support custom AutoScrollController for Scrollbar compatibility

### DIFF
--- a/lib/widget/markdown.dart
+++ b/lib/widget/markdown.dart
@@ -13,6 +13,9 @@ class MarkdownWidget extends StatefulWidget {
   ///if [tocController] is not null, you can use [tocListener] to get current TOC index
   final TocController? tocController;
 
+  ///[AutoScrollController] provides the scroll to index mechanism
+  final AutoScrollController? autoScrollController;
+
   ///set the desired scroll physics for the markdown item list
   final ScrollPhysics? physics;
 
@@ -35,6 +38,7 @@ class MarkdownWidget extends StatefulWidget {
     Key? key,
     required this.data,
     this.tocController,
+    this.autoScrollController,
     this.physics,
     this.shrinkWrap = false,
     this.selectable = true,
@@ -58,7 +62,7 @@ class MarkdownWidgetState extends State<MarkdownWidget> {
   TocController? _tocController;
 
   ///[AutoScrollController] provides the scroll to index mechanism
-  final AutoScrollController controller = AutoScrollController();
+  late AutoScrollController _controller;
 
   ///every [VisibilityDetector]'s child which is visible will be kept with [indexTreeSet]
   final indexTreeSet = SplayTreeSet<int>((a, b) => a - b);
@@ -69,9 +73,10 @@ class MarkdownWidgetState extends State<MarkdownWidget> {
   @override
   void initState() {
     super.initState();
+    _controller = widget.autoScrollController ?? AutoScrollController();
     _tocController = widget.tocController;
     _tocController?.jumpToIndexCallback = (index) {
-      controller.scrollToIndex(index, preferPosition: AutoScrollPosition.begin);
+      _controller.scrollToIndex(index, preferPosition: AutoScrollPosition.begin);
     };
     updateState();
   }
@@ -99,7 +104,7 @@ class MarkdownWidgetState extends State<MarkdownWidget> {
   @override
   void dispose() {
     clearState();
-    controller.dispose();
+    _controller.dispose();
     _tocController?.jumpToIndexCallback = null;
     super.dispose();
   }
@@ -118,9 +123,9 @@ class MarkdownWidgetState extends State<MarkdownWidget> {
       child: ListView.builder(
         shrinkWrap: widget.shrinkWrap,
         physics: widget.physics,
-        controller: controller,
+        controller: _controller,
         itemBuilder: (ctx, index) => wrapByAutoScroll(index,
-            wrapByVisibilityDetector(index, _widgets[index]), controller),
+            wrapByVisibilityDetector(index, _widgets[index]), _controller),
         itemCount: _widgets.length,
         padding: widget.padding,
       ),


### PR DESCRIPTION
## 遇到問題

想使用 Scrollbar 或 RawScrollbar 顯示捲軸時出現錯誤訊息

```
════════ Exception caught by scheduler library ═════════════════════════════════
The following assertion was thrown during a scheduler callback:
The Scrollbar's ScrollController has no ScrollPosition attached.
A Scrollbar cannot be painted without a ScrollPosition.
The Scrollbar attempted to use the provided ScrollController. This ScrollController should be associated with the ScrollView that the Scrollbar is being applied to.
When providing your own ScrollController, ensure both the Scrollbar and the Scrollable widget use the same one.
```

## 修改方式
參考 [Stack Overflow 69853729](https://stackoverflow.com/questions/69853729/flutter-the-scrollbars-scrollcontroller-has-no-scrollposition-attached)，允許從外部傳入 AutoScrollController。

## 修改後使用範例
```
import 'package:flutter/material.dart';
import 'package:markdown_widget/markdown_widget.dart';
import 'package:scroll_to_index/scroll_to_index.dart';

class TestPage extends StatefulWidget {
  const TestPage({super.key});

  @override
  TestPageState createState() => TestPageState();
}

class TestPageState extends State<TestPage> {
  final AutoScrollController controller = AutoScrollController();

  String md() {
    return '''test
''';
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: Text('test')),
      body: Container(
        color: Colors.white,
        padding: EdgeInsets.all(10),
        height: 250,
        child: RawScrollbar(
          controller: controller,
          thumbVisibility: true,
          child: MarkdownWidget(
            autoScrollController: controller,
            padding: EdgeInsets.all(12),
            shrinkWrap: true,
            data: md() * 100,
          ),
        ),
      ),
    );
  }
}
```

## 截圖

![截圖 2025-07-07 上午8 22 22](https://github.com/user-attachments/assets/c2e1b1dd-ca27-43eb-8a1e-eeddae18eb67)
