### PR TITLE
feat: :sparkles: Add selectionControls to MarkdownBlock

### DIFF
--- a/lib/widget/markdown_block.dart
+++ b/lib/widget/markdown_block.dart
@@ -18,12 +18,16 @@ class MarkdownBlock extends StatelessWidget {
   ///to generator markdown data
   final MarkdownGenerator? generator;
 
+  ///the selection controls
+  final TextSelectionControls? selectionControls;
+
   const MarkdownBlock({
     Key? key,
     required this.data,
     this.selectable = true,
     this.config,
     this.generator,
+    this.selectionControls,
   }) : super(key: key);
 
   @override
@@ -35,6 +39,6 @@ class MarkdownBlock extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
     );
-    return selectable ? SelectionArea(child: column) : column;
+    return selectable ? SelectionArea(child: column, selectionControls: selectionControls) : column;
   }
 }


### PR DESCRIPTION
## Add `selectionControls` to `MarkdownBlock`
This PR introduces an optional `selectionControls` parameter to the `MarkdownBlock` widget. It allows developers to provide custom `TextSelectionControls`, enabling use cases such as tracking copy actions for analytics.

The change is fully backward compatible and does not affect existing behavior when the parameter is not provided.