### PR TITLE
feat: Add word-level tap detection and highlighting functionality

### DIFF
--- a/example/lib/pages/router.dart
+++ b/example/lib/pages/router.dart
@@ -8,6 +8,7 @@ import 'home_page.dart';
 import 'markdown_page.dart';
 import 'sample_html_page.dart';
 import 'sample_latex_page.dart';
+import '../word_tap_example.dart';
 
 final GlobalKey<NavigatorState> _rootNavigatorKey =
     GlobalKey<NavigatorState>(debugLabel: 'root');
@@ -39,6 +40,7 @@ final GoRouter router = GoRouter(
         _buildRoute(RouterEnum.editor, EditMarkdownPage()),
         _buildRoute(RouterEnum.sample_latex, LatexPage()),
         _buildRoute(RouterEnum.sample_html, HtmlPage()),
+        _buildRoute(RouterEnum.word_tap, WordTapExample()),
       ],
     ),
   ],
@@ -95,6 +97,7 @@ enum RouterEnum {
   editor,
   sample_latex,
   sample_html,
+  word_tap,
 }
 
 extension RoutePath on RouterEnum {

--- a/example/lib/widget/menu.dart
+++ b/example/lib/widget/menu.dart
@@ -74,6 +74,16 @@ class Menu extends StatelessWidget {
                     if (isMobile) Navigator.of(context).pop();
                   },
                 ),
+                NavItem(
+                  title: 'Word Tap Demo',
+                  trailing: '👆',
+                  isSelected: isSelected(RouterEnum.word_tap),
+                  isCollapsed: isCollapsed,
+                  onTap: () {
+                    GoRouter.of(context).go(RouterEnum.word_tap.path);
+                    if (isMobile) Navigator.of(context).pop();
+                  },
+                ),
               ],
             ),
           ),

--- a/example/lib/word_tap_example.dart
+++ b/example/lib/word_tap_example.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:markdown_widget/markdown_widget.dart';
+
+/// Example demonstrating the onTapWord callback and word highlighting functionality
+class WordTapExample extends StatefulWidget {
+  const WordTapExample({Key? key}) : super(key: key);
+
+  @override
+  State<WordTapExample> createState() => _WordTapExampleState();
+}
+
+class _WordTapExampleState extends State<WordTapExample> {
+  String? lastTappedWord;
+
+  void _onWordTap(String word) {
+    setState(() {
+      lastTappedWord = word;
+    });
+
+    // Show a snackbar with the tapped word
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('Tapped word: "$word"'),
+        duration: const Duration(seconds: 1),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const markdownData = '''
+# Word Tap & Highlight Demo
+
+This is a paragraph where you can **tap on any word** to see it highlighted with a yellow background.
+
+Try tapping on *different* words like **bold**, *italic*, or `code` to see the highlighting in action!
+
+## Features
+
+- Tap any word in a paragraph to highlight it
+- Custom highlight styling (background color, font weight, etc.)
+- Preserves formatting (bold, italic, code)
+- Maintains text layout and spacing
+- Works with markdown links and other inline elements
+- **NEW**: Word tapping also works in list items!
+
+### List Examples
+
+Tap on words in these lists:
+
+- This is a **bulleted** list item
+- You can tap any `word` here
+- Even *italic* words work
+
+1. This is a **numbered** list
+2. Try tapping `different` words
+3. Highlighting works in *ordered* lists too
+
+> Note: Word tapping and highlighting now works in both paragraphs and list items!
+''';
+
+    // Create a custom config with onTapWord callback and highlighting
+    final config = MarkdownConfig.defaultConfig.copy(
+      configs: [
+        PConfig(
+          textStyle: const TextStyle(fontSize: 16),
+          onTapWord: _onWordTap,
+          highlightStyle: const TextStyle(
+            backgroundColor: Colors.yellow,
+            fontWeight: FontWeight.bold,
+          ),
+          highlightedWord: lastTappedWord,
+        ),
+        ListConfig(
+          onTapWord: _onWordTap,
+          highlightStyle: const TextStyle(
+            backgroundColor: Colors.yellow,
+            fontWeight: FontWeight.bold,
+          ),
+          highlightedWord: lastTappedWord,
+        ),
+      ],
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Word Tap Example'),
+      ),
+      body: Column(
+        children: [
+          // Status display
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(16),
+            color: Colors.grey.shade100,
+            child: Text(
+              lastTappedWord != null ? 'Last tapped word: "$lastTappedWord"' : 'Tap any word in the markdown below',
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+
+          // Markdown content with word tap functionality
+          Expanded(
+            child: MarkdownWidget(
+              data: markdownData,
+              config: config,
+              padding: const EdgeInsets.all(16),
+              selectable: false,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/widget/blocks/container/list.dart
+++ b/lib/widget/blocks/container/list.dart
@@ -154,10 +154,22 @@ class ListConfig implements ContainerConfig {
   ///the marker widget for list
   final ListMarker? marker;
 
+  ///callback for word tap events
+  final ValueCallback<String>? onTapWord;
+
+  ///style for highlighted words
+  final TextStyle? highlightStyle;
+
+  ///the currently highlighted word
+  final String? highlightedWord;
+
   const ListConfig({
     this.marginLeft = 32.0,
     this.marginBottom = 4.0,
     this.marker,
+    this.onTapWord,
+    this.highlightStyle,
+    this.highlightedWord,
   });
 
   @nonVirtual

--- a/lib/widget/blocks/leaf/paragraph.dart
+++ b/lib/widget/blocks/leaf/paragraph.dart
@@ -27,8 +27,16 @@ class ParagraphNode extends ElementNode {
 ///config class for paragraphs, tag: p
 class PConfig implements LeafConfig {
   final TextStyle textStyle;
+  final ValueCallback<String>? onTapWord;
+  final TextStyle? highlightStyle;
+  final String? highlightedWord;
 
-  const PConfig({this.textStyle = const TextStyle(fontSize: 16)});
+  const PConfig({
+    this.textStyle = const TextStyle(fontSize: 16),
+    this.onTapWord,
+    this.highlightStyle,
+    this.highlightedWord,
+  });
 
   static PConfig get darkConfig =>
       PConfig(textStyle: const TextStyle(fontSize: 16));

--- a/lib/widget/span_node.dart
+++ b/lib/widget/span_node.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 ///the basic node
@@ -62,4 +63,78 @@ class TextNode extends SpanNode {
 
   @override
   InlineSpan build() => TextSpan(text: text, style: style?.merge(parentStyle));
+}
+
+///text node that supports word-level tap detection
+class TappableTextNode extends SpanNode {
+  final String text;
+  final void Function(String)? onTapWord;
+  final TextStyle? highlightStyle;
+  final String? highlightedWord;
+
+  TappableTextNode({
+    this.text = '',
+    TextStyle? style,
+    this.onTapWord,
+    this.highlightStyle,
+    this.highlightedWord,
+  }) {
+    this.style = style ?? const TextStyle();
+  }
+
+  @override
+  InlineSpan build() {
+    if (onTapWord == null) {
+      return TextSpan(text: text, style: style?.merge(parentStyle));
+    }
+
+    // Split text into words and spaces, preserving whitespace
+    final parts = splitTextWithSpaces(text);
+    final List<InlineSpan> spans = [];
+
+    for (final part in parts) {
+      if (part.trim().isEmpty) {
+        // This is whitespace, add as non-tappable
+        spans.add(TextSpan(text: part, style: style?.merge(parentStyle)));
+      } else {
+        // This is a word, make it tappable
+        spans.add(_createTappableWordSpan(part));
+      }
+    }
+
+    return TextSpan(children: spans);
+  }
+
+  /// Splits text into words and spaces, preserving all whitespace
+  List<String> splitTextWithSpaces(String text) {
+    final List<String> parts = [];
+    final RegExp wordPattern = RegExp(r'\S+|\s+');
+    final matches = wordPattern.allMatches(text);
+
+    for (final match in matches) {
+      parts.add(match.group(0)!);
+    }
+
+    return parts;
+  }
+
+  /// Creates a tappable TextSpan for a word
+  TextSpan _createTappableWordSpan(String word) {
+    // Check if this word should be highlighted
+    final isHighlighted = highlightedWord != null &&
+                         word.toLowerCase().trim() == highlightedWord!.toLowerCase().trim();
+
+    // Apply highlight style if word is highlighted
+    final baseStyle = style?.merge(parentStyle);
+    final effectiveStyle = isHighlighted && highlightStyle != null
+        ? baseStyle?.merge(highlightStyle!)
+        : baseStyle;
+
+    return TextSpan(
+      text: word,
+      style: effectiveStyle,
+      recognizer: TapGestureRecognizer()
+        ..onTap = () => onTapWord?.call(word),
+    );
+  }
 }

--- a/lib/widget/widget_visitor.dart
+++ b/lib/widget/widget_visitor.dart
@@ -94,10 +94,34 @@ class WidgetVisitor implements m.NodeVisitor {
     final last = _spansStack.last;
     if (last is ElementNode) {
       final textNode = textGenerator?.call(text, config, this) ??
-          TextNode(text: text.text, style: config.p.textStyle);
+          _createTextNode(text, last);
       last.accept(textNode);
       onNodeAccepted?.call(textNode, _currentSpanIndex);
     }
+  }
+
+  SpanNode _createTextNode(m.Text text, ElementNode parent) {
+    if (parent is ParagraphNode && parent.pConfig.onTapWord != null) {
+      return TappableTextNode(
+        text: text.text,
+        style: config.p.textStyle,
+        onTapWord: parent.pConfig.onTapWord,
+        highlightStyle: parent.pConfig.highlightStyle,
+        highlightedWord: parent.pConfig.highlightedWord,
+      );
+    }
+
+    if (parent is ListNode && config.li.onTapWord != null) {
+      return TappableTextNode(
+        text: text.text,
+        style: config.p.textStyle,
+        onTapWord: config.li.onTapWord,
+        highlightStyle: config.li.highlightStyle,
+        highlightedWord: config.li.highlightedWord,
+      );
+    }
+
+    return TextNode(text: text.text, style: config.p.textStyle);
   }
 
   ///every tag has it's own [SpanNodeGenerator]

--- a/test/word_tap_test.dart
+++ b/test/word_tap_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:markdown_widget/widget/span_node.dart';
+
+void main() {
+  group('TappableTextNode', () {
+    test('should create tappable spans for words', () {
+      final node = TappableTextNode(
+        text: 'Hello world test',
+        onTapWord: (word) {},
+      );
+
+      final span = node.build() as TextSpan;
+
+      // Should create a TextSpan with children (words + spaces)
+      expect(span.children, isNotNull);
+      expect(span.children!.length, greaterThan(0));
+    });
+
+    test('should split text correctly preserving whitespace', () {
+      final node = TappableTextNode(
+        text: 'Hello  world\ttest\n',
+        onTapWord: (word) {},
+      );
+
+      final parts = node.splitTextWithSpaces('Hello  world\ttest\n');
+
+      expect(parts, [
+        'Hello',
+        '  ',
+        'world',
+        '\t',
+        'test',
+        '\n',
+      ]);
+    });
+
+    test('should handle punctuation in words', () {
+      final node = TappableTextNode(
+        text: 'Hello, world! How are you?',
+        onTapWord: (word) {},
+      );
+
+      final parts = node.splitTextWithSpaces('Hello, world! How are you?');
+
+      expect(parts, [
+        'Hello,',
+        ' ',
+        'world!',
+        ' ',
+        'How',
+        ' ',
+        'are',
+        ' ',
+        'you?',
+      ]);
+    });
+
+    test('should fallback to regular TextSpan when no callback', () {
+      final node = TappableTextNode(
+        text: 'Hello world',
+        onTapWord: null,
+      );
+
+      final span = node.build() as TextSpan;
+
+      // Should create a simple TextSpan without children
+      expect(span.children, isNull);
+      expect(span.toPlainText(), equals('Hello world'));
+    });
+  });
+}


### PR DESCRIPTION
## Core Features
- **Word Tap Detection**: Individual words in paragraphs and list items can be tapped
- **Word Highlighting**: Tapped words are highlighted with customizable TextStyle
- **Multi-instance Highlighting**: All instances of the same word are highlighted
- **Case-insensitive Matching**: Word matching ignores case differences

## Example Integration
- Added comprehensive demo in `WordTapExample`
- Integrated into main example app with proper navigation
- Includes tests for core functionality

## API Usage
```dart
PConfig(
  onTapWord: (word) => print('Tapped: $word'),
  highlightStyle: TextStyle(backgroundColor: Colors.yellow),
  highlightedWord: lastTappedWord,
)
```