### PR TITLE
fix: update TBodyNode style to use bodyStyle instead of headerStyle

### DIFF
--- a/lib/widget/blocks/container/table.dart
+++ b/lib/widget/blocks/container/table.dart
@@ -142,7 +142,7 @@ class TBodyNode extends ElementNode {
 
   @override
   TextStyle? get style =>
-      config.table.headerStyle?.merge(parentStyle) ??
+      config.table.bodyStyle?.merge(parentStyle) ??
       parentStyle ??
       config.p.textStyle;
 }


### PR DESCRIPTION
Currently, where the `TableConfig.headerStyle` is applied to both the header and body styles simultaneously.

Setting `TableConfig.bodyStyle` has no effect.