### PR TITLE
fix: TocContoller.jumpToIndex stop working if MarkdoThewnWidget instance is replaced

### DIFF
--- a/example/lib/platform_detector/web_detector.dart
+++ b/example/lib/platform_detector/web_detector.dart
@@ -1,5 +1,4 @@
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
+import 'package:web/web.dart';
 import 'platform_detector.dart';
 
 PlatformType get currentType {
@@ -20,8 +19,8 @@ final _iOS = [
 bool isWebIOS() {
   var matches = false;
   _iOS.forEach((name) {
-    if (html.window.navigator.platform?.contains(name) ??
-        false || html.window.navigator.userAgent.contains(name)) {
+    if (window.navigator.platform.contains(name) ||
+        window.navigator.userAgent.contains(name)) {
       matches = true;
     }
   });
@@ -29,5 +28,5 @@ bool isWebIOS() {
 }
 
 bool isWebAndroid() =>
-    html.window.navigator.platform == "Android" ||
-    html.window.navigator.userAgent.contains("Android");
+    window.navigator.platform == "Android" ||
+    window.navigator.userAgent.contains("Android");

--- a/lib/widget/markdown.dart
+++ b/lib/widget/markdown.dart
@@ -65,12 +65,15 @@ class MarkdownWidgetState extends State<MarkdownWidget> {
 
   ///if the [ScrollDirection] of [ListView] is [ScrollDirection.forward], [isForward] will be true
   bool isForward = true;
+  
+  bool _isDisposed = false;
 
   @override
   void initState() {
     super.initState();
     _tocController = widget.tocController;
     _tocController?.jumpToWidgetIndexCallback = (index) {
+      if (_isDisposed) return;
       controller.scrollToIndex(index, preferPosition: AutoScrollPosition.begin);
     };
     updateState();
@@ -101,9 +104,10 @@ class MarkdownWidgetState extends State<MarkdownWidget> {
 
   @override
   void dispose() {
+    if (_isDisposed) return;
+    _isDisposed = true;
     clearState();
     controller.dispose();
-    _tocController?.jumpToWidgetIndexCallback = null;
     super.dispose();
   }
 

--- a/lib/widget/markdown.dart
+++ b/lib/widget/markdown.dart
@@ -30,6 +30,8 @@ class MarkdownWidget extends StatefulWidget {
 
   ///config for [MarkdownGenerator]
   final MarkdownGenerator? markdownGenerator;
+  
+  final AutoScrollController? _autoScrollController;
 
   const MarkdownWidget({
     Key? key,
@@ -41,7 +43,8 @@ class MarkdownWidget extends StatefulWidget {
     this.padding,
     this.config,
     this.markdownGenerator,
-  }) : super(key: key);
+    AutoScrollController? autoScrollController
+  }) : _autoScrollController = autoScrollController, super(key: key);
 
   @override
   MarkdownWidgetState createState() => MarkdownWidgetState();
@@ -58,7 +61,7 @@ class MarkdownWidgetState extends State<MarkdownWidget> {
   TocController? _tocController;
 
   ///[AutoScrollController] provides the scroll to index mechanism
-  final AutoScrollController controller = AutoScrollController();
+  late AutoScrollController controller;
 
   ///every [VisibilityDetector]'s child which is visible will be kept with [indexTreeSet]
   final indexTreeSet = SplayTreeSet<int>((a, b) => a - b);
@@ -72,6 +75,7 @@ class MarkdownWidgetState extends State<MarkdownWidget> {
   void initState() {
     super.initState();
     _tocController = widget.tocController;
+    controller = widget._autoScrollController ??  AutoScrollController();
     _tocController?.jumpToWidgetIndexCallback = (index) {
       if (_isDisposed) return;
       controller.scrollToIndex(index, preferPosition: AutoScrollPosition.begin);


### PR DESCRIPTION
Removed  `TocContoller.jumpToWidgetIndexCallback` unset on `MarkdownWidgetState.dispose` and add `isDisposed` check on `jumpToWidgetIndexCallback` implementation.

This avoid `TocContoller` stop working if `MarkdownWidget` is replaced by a new instance and old instance is disposed.

This happens for example in adaptive layouts implementation or multi language support, when `MarkdoThewnWidget` is replaced but `TocContoller` remain the same.

 The `isDisposed` check preserve jumpToWidgetIndexCallback invocation after the `MarkdoThewnWidget` is disposed,