### PR TITLE
Merge upstream/master: sync fork with upstream, resolve ListConfig conflict

### DIFF
--- a/example/lib/pages/router.dart
+++ b/example/lib/pages/router.dart
@@ -8,6 +8,7 @@ import 'home_page.dart';
 import 'markdown_page.dart';
 import 'sample_html_page.dart';
 import 'sample_latex_page.dart';
+import '../word_tap_example.dart';
 
 final GlobalKey<NavigatorState> _rootNavigatorKey =
     GlobalKey<NavigatorState>(debugLabel: 'root');
@@ -39,6 +40,7 @@ final GoRouter router = GoRouter(
         _buildRoute(RouterEnum.editor, EditMarkdownPage()),
         _buildRoute(RouterEnum.sample_latex, LatexPage()),
         _buildRoute(RouterEnum.sample_html, HtmlPage()),
+        _buildRoute(RouterEnum.word_tap, WordTapExample()),
       ],
     ),
   ],
@@ -95,6 +97,7 @@ enum RouterEnum {
   editor,
   sample_latex,
   sample_html,
+  word_tap,
 }
 
 extension RoutePath on RouterEnum {

--- a/example/lib/widget/menu.dart
+++ b/example/lib/widget/menu.dart
@@ -74,6 +74,16 @@ class Menu extends StatelessWidget {
                     if (isMobile) Navigator.of(context).pop();
                   },
                 ),
+                NavItem(
+                  title: 'Word Tap Demo',
+                  trailing: '👆',
+                  isSelected: isSelected(RouterEnum.word_tap),
+                  isCollapsed: isCollapsed,
+                  onTap: () {
+                    GoRouter.of(context).go(RouterEnum.word_tap.path);
+                    if (isMobile) Navigator.of(context).pop();
+                  },
+                ),
               ],
             ),
           ),

--- a/example/lib/word_tap_example.dart
+++ b/example/lib/word_tap_example.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:markdown_widget/markdown_widget.dart';
+
+/// Example demonstrating the onTapWord callback and word highlighting functionality
+class WordTapExample extends StatefulWidget {
+  const WordTapExample({Key? key}) : super(key: key);
+
+  @override
+  State<WordTapExample> createState() => _WordTapExampleState();
+}
+
+class _WordTapExampleState extends State<WordTapExample> {
+  String? lastTappedWord;
+
+  void _onWordTap(String word) {
+    setState(() {
+      lastTappedWord = word;
+    });
+
+    // Show a snackbar with the tapped word
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('Tapped word: "$word"'),
+        duration: const Duration(seconds: 1),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const markdownData = '''
+# Word Tap & Highlight Demo
+
+This is a paragraph where you can **tap on any word** to see it highlighted with a yellow background.
+
+Try tapping on *different* words like **bold**, *italic*, or `code` to see the highlighting in action!
+
+## Features
+
+- Tap any word in a paragraph to highlight it
+- Custom highlight styling (background color, font weight, etc.)
+- Preserves formatting (bold, italic, code)
+- Maintains text layout and spacing
+- Works with markdown links and other inline elements
+- **NEW**: Word tapping also works in list items!
+
+### List Examples
+
+Tap on words in these lists:
+
+- This is a **bulleted** list item
+- You can tap any `word` here
+- Even *italic* words work
+
+1. This is a **numbered** list
+2. Try tapping `different` words
+3. Highlighting works in *ordered* lists too
+
+> Note: Word tapping and highlighting now works in both paragraphs and list items!
+''';
+
+    // Create a custom config with onTapWord callback and highlighting
+    final config = MarkdownConfig.defaultConfig.copy(
+      configs: [
+        PConfig(
+          textStyle: const TextStyle(fontSize: 16),
+          onTapWord: _onWordTap,
+          highlightStyle: const TextStyle(
+            backgroundColor: Colors.yellow,
+            fontWeight: FontWeight.bold,
+          ),
+          highlightedWord: lastTappedWord,
+        ),
+        ListConfig(
+          onTapWord: _onWordTap,
+          highlightStyle: const TextStyle(
+            backgroundColor: Colors.yellow,
+            fontWeight: FontWeight.bold,
+          ),
+          highlightedWord: lastTappedWord,
+        ),
+      ],
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Word Tap Example'),
+      ),
+      body: Column(
+        children: [
+          // Status display
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(16),
+            color: Colors.grey.shade100,
+            child: Text(
+              lastTappedWord != null ? 'Last tapped word: "$lastTappedWord"' : 'Tap any word in the markdown below',
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+
+          // Markdown content with word tap functionality
+          Expanded(
+            child: MarkdownWidget(
+              data: markdownData,
+              config: config,
+              padding: const EdgeInsets.all(16),
+              selectable: false,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/example/lib/word_tap_example.dart
+++ b/example/lib/word_tap_example.dart
@@ -1,6 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:markdown_widget/markdown_widget.dart';
 
+void main() {
+  runApp(const MaterialApp(
+    home: WordTapExample(),
+  ));
+}
+
 /// Example demonstrating the onTapWord callback and word highlighting functionality
 class WordTapExample extends StatefulWidget {
   const WordTapExample({Key? key}) : super(key: key);
@@ -37,16 +43,16 @@ Try tapping on *different* words like **bold**, *italic*, or `code` to see the h
 
 ## Features
 
-- Tap any word in a paragraph to highlight it
+- Tap any word in any markdown element to highlight it
 - Custom highlight styling (background color, font weight, etc.)
 - Preserves formatting (bold, italic, code)
 - Maintains text layout and spacing
 - Works with markdown links and other inline elements
-- **NEW**: Word tapping also works in list items!
+- **NEW**: Word tapping now works in ALL text-containing elements!
 
-### List Examples
+### Works Everywhere
 
-Tap on words in these lists:
+Tap on words in these different elements:
 
 - This is a **bulleted** list item
 - You can tap any `word` here
@@ -56,31 +62,12 @@ Tap on words in these lists:
 2. Try tapping `different` words
 3. Highlighting works in *ordered* lists too
 
-> Note: Word tapping and highlighting now works in both paragraphs and list items!
-''';
+> This is a blockquote. Try tapping on any word here! Even in **blockquotes**, the word tap functionality works perfectly.
 
-    // Create a custom config with onTapWord callback and highlighting
-    final config = MarkdownConfig.defaultConfig.copy(
-      configs: [
-        PConfig(
-          textStyle: const TextStyle(fontSize: 16),
-          onTapWord: _onWordTap,
-          highlightStyle: const TextStyle(
-            backgroundColor: Colors.yellow,
-            fontWeight: FontWeight.bold,
-          ),
-          highlightedWord: lastTappedWord,
-        ),
-        ListConfig(
-          onTapWord: _onWordTap,
-          highlightStyle: const TextStyle(
-            backgroundColor: Colors.yellow,
-            fontWeight: FontWeight.bold,
-          ),
-          highlightedWord: lastTappedWord,
-        ),
-      ],
-    );
+#### Headings Are Tappable Too!
+
+Tap on words in headings, paragraphs, lists, and blockquotes - everything is now tappable with just a single configuration at the MarkdownWidget level!
+''';
 
     return Scaffold(
       appBar: AppBar(
@@ -103,12 +90,18 @@ Tap on words in these lists:
           ),
 
           // Markdown content with word tap functionality
+          // Note: No custom config needed! Just pass the callbacks directly to MarkdownWidget
           Expanded(
             child: MarkdownWidget(
               data: markdownData,
-              config: config,
               padding: const EdgeInsets.all(16),
               selectable: false,
+              onTapWord: _onWordTap,
+              highlightStyle: const TextStyle(
+                backgroundColor: Colors.yellow,
+                fontWeight: FontWeight.bold,
+              ),
+              highlightedWord: lastTappedWord,
             ),
           ),
         ],

--- a/lib/config/markdown_generator.dart
+++ b/lib/config/markdown_generator.dart
@@ -45,7 +45,11 @@ class MarkdownGenerator {
   ///convert [data] to widgets
   ///[onTocList] can provider [Toc] list
   List<Widget> buildWidgets(String data,
-      {ValueCallback<List<Toc>>? onTocList, MarkdownConfig? config}) {
+      {ValueCallback<List<Toc>>? onTocList,
+      MarkdownConfig? config,
+      ValueCallback<String>? onTapWord,
+      TextStyle? highlightStyle,
+      String? highlightedWord}) {
     final mdConfig = config ?? MarkdownConfig.defaultConfig;
     final m.Document document = m.Document(
       extensionSet: extensionSet ?? m.ExtensionSet.gitHubFlavored,
@@ -63,6 +67,9 @@ class MarkdownGenerator {
         textGenerator: textGenerator,
         richTextBuilder: richTextBuilder,
         splitRegExp: regExp,
+        onTapWord: onTapWord,
+        highlightStyle: highlightStyle,
+        highlightedWord: highlightedWord,
         onNodeAccepted: (node, index) {
           onNodeAccepted?.call(node, index);
           if (node is HeadingNode && headingNodeFilter(node)) {

--- a/lib/widget/blocks/container/list.dart
+++ b/lib/widget/blocks/container/list.dart
@@ -154,10 +154,22 @@ class ListConfig implements ContainerConfig {
   ///the marker widget for list
   final ListMarker? marker;
 
+  ///callback for word tap events
+  final ValueCallback<String>? onTapWord;
+
+  ///style for highlighted words
+  final TextStyle? highlightStyle;
+
+  ///the currently highlighted word
+  final String? highlightedWord;
+
   const ListConfig({
     this.marginLeft = 32.0,
     this.marginBottom = 4.0,
     this.marker,
+    this.onTapWord,
+    this.highlightStyle,
+    this.highlightedWord,
   });
 
   @nonVirtual

--- a/lib/widget/blocks/leaf/paragraph.dart
+++ b/lib/widget/blocks/leaf/paragraph.dart
@@ -27,8 +27,16 @@ class ParagraphNode extends ElementNode {
 ///config class for paragraphs, tag: p
 class PConfig implements LeafConfig {
   final TextStyle textStyle;
+  final ValueCallback<String>? onTapWord;
+  final TextStyle? highlightStyle;
+  final String? highlightedWord;
 
-  const PConfig({this.textStyle = const TextStyle(fontSize: 16)});
+  const PConfig({
+    this.textStyle = const TextStyle(fontSize: 16),
+    this.onTapWord,
+    this.highlightStyle,
+    this.highlightedWord,
+  });
 
   static PConfig get darkConfig =>
       PConfig(textStyle: const TextStyle(fontSize: 16));

--- a/lib/widget/markdown.dart
+++ b/lib/widget/markdown.dart
@@ -31,6 +31,15 @@ class MarkdownWidget extends StatefulWidget {
   ///config for [MarkdownGenerator]
   final MarkdownGenerator? markdownGenerator;
 
+  ///callback for word tap events in all text-containing elements
+  final ValueCallback<String>? onTapWord;
+
+  ///style for highlighted words in all text-containing elements
+  final TextStyle? highlightStyle;
+
+  ///the currently highlighted word in all text-containing elements
+  final String? highlightedWord;
+
   const MarkdownWidget({
     Key? key,
     required this.data,
@@ -41,6 +50,9 @@ class MarkdownWidget extends StatefulWidget {
     this.padding,
     this.config,
     this.markdownGenerator,
+    this.onTapWord,
+    this.highlightStyle,
+    this.highlightedWord,
   }) : super(key: key);
 
   @override
@@ -86,6 +98,9 @@ class MarkdownWidgetState extends State<MarkdownWidget> {
         _tocController?.setTocList(tocList);
       },
       config: widget.config,
+      onTapWord: widget.onTapWord,
+      highlightStyle: widget.highlightStyle,
+      highlightedWord: widget.highlightedWord,
     );
     _widgets.addAll(result);
   }

--- a/lib/widget/span_node.dart
+++ b/lib/widget/span_node.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 ///the basic node
@@ -62,4 +63,78 @@ class TextNode extends SpanNode {
 
   @override
   InlineSpan build() => TextSpan(text: text, style: style?.merge(parentStyle));
+}
+
+///text node that supports word-level tap detection
+class TappableTextNode extends SpanNode {
+  final String text;
+  final void Function(String)? onTapWord;
+  final TextStyle? highlightStyle;
+  final String? highlightedWord;
+
+  TappableTextNode({
+    this.text = '',
+    TextStyle? style,
+    this.onTapWord,
+    this.highlightStyle,
+    this.highlightedWord,
+  }) {
+    this.style = style ?? const TextStyle();
+  }
+
+  @override
+  InlineSpan build() {
+    if (onTapWord == null) {
+      return TextSpan(text: text, style: style?.merge(parentStyle));
+    }
+
+    // Split text into words and spaces, preserving whitespace
+    final parts = splitTextWithSpaces(text);
+    final List<InlineSpan> spans = [];
+
+    for (final part in parts) {
+      if (part.trim().isEmpty) {
+        // This is whitespace, add as non-tappable
+        spans.add(TextSpan(text: part, style: style?.merge(parentStyle)));
+      } else {
+        // This is a word, make it tappable
+        spans.add(_createTappableWordSpan(part));
+      }
+    }
+
+    return TextSpan(children: spans);
+  }
+
+  /// Splits text into words and spaces, preserving all whitespace
+  List<String> splitTextWithSpaces(String text) {
+    final List<String> parts = [];
+    final RegExp wordPattern = RegExp(r'\S+|\s+');
+    final matches = wordPattern.allMatches(text);
+
+    for (final match in matches) {
+      parts.add(match.group(0)!);
+    }
+
+    return parts;
+  }
+
+  /// Creates a tappable TextSpan for a word
+  TextSpan _createTappableWordSpan(String word) {
+    // Check if this word should be highlighted
+    final isHighlighted = highlightedWord != null &&
+                         word.toLowerCase().trim() == highlightedWord!.toLowerCase().trim();
+
+    // Apply highlight style if word is highlighted
+    final baseStyle = style?.merge(parentStyle);
+    final effectiveStyle = isHighlighted && highlightStyle != null
+        ? baseStyle?.merge(highlightStyle!)
+        : baseStyle;
+
+    return TextSpan(
+      text: word,
+      style: effectiveStyle,
+      recognizer: TapGestureRecognizer()
+        ..onTap = () => onTapWord?.call(word),
+    );
+  }
 }

--- a/lib/widget/widget_visitor.dart
+++ b/lib/widget/widget_visitor.dart
@@ -94,10 +94,34 @@ class WidgetVisitor implements m.NodeVisitor {
     final last = _spansStack.last;
     if (last is ElementNode) {
       final textNode = textGenerator?.call(text, config, this) ??
-          TextNode(text: text.text, style: config.p.textStyle);
+          _createTextNode(text, last);
       last.accept(textNode);
       onNodeAccepted?.call(textNode, _currentSpanIndex);
     }
+  }
+
+  SpanNode _createTextNode(m.Text text, ElementNode parent) {
+    if (parent is ParagraphNode && parent.pConfig.onTapWord != null) {
+      return TappableTextNode(
+        text: text.text,
+        style: config.p.textStyle,
+        onTapWord: parent.pConfig.onTapWord,
+        highlightStyle: parent.pConfig.highlightStyle,
+        highlightedWord: parent.pConfig.highlightedWord,
+      );
+    }
+
+    if (parent is ListNode && config.li.onTapWord != null) {
+      return TappableTextNode(
+        text: text.text,
+        style: config.p.textStyle,
+        onTapWord: config.li.onTapWord,
+        highlightStyle: config.li.highlightStyle,
+        highlightedWord: config.li.highlightedWord,
+      );
+    }
+
+    return TextNode(text: text.text, style: config.p.textStyle);
   }
 
   ///every tag has it's own [SpanNodeGenerator]

--- a/test/word_tap_test.dart
+++ b/test/word_tap_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:markdown_widget/widget/span_node.dart';
+
+void main() {
+  group('TappableTextNode', () {
+    test('should create tappable spans for words', () {
+      final node = TappableTextNode(
+        text: 'Hello world test',
+        onTapWord: (word) {},
+      );
+
+      final span = node.build() as TextSpan;
+
+      // Should create a TextSpan with children (words + spaces)
+      expect(span.children, isNotNull);
+      expect(span.children!.length, greaterThan(0));
+    });
+
+    test('should split text correctly preserving whitespace', () {
+      final node = TappableTextNode(
+        text: 'Hello  world\ttest\n',
+        onTapWord: (word) {},
+      );
+
+      final parts = node.splitTextWithSpaces('Hello  world\ttest\n');
+
+      expect(parts, [
+        'Hello',
+        '  ',
+        'world',
+        '\t',
+        'test',
+        '\n',
+      ]);
+    });
+
+    test('should handle punctuation in words', () {
+      final node = TappableTextNode(
+        text: 'Hello, world! How are you?',
+        onTapWord: (word) {},
+      );
+
+      final parts = node.splitTextWithSpaces('Hello, world! How are you?');
+
+      expect(parts, [
+        'Hello,',
+        ' ',
+        'world!',
+        ' ',
+        'How',
+        ' ',
+        'are',
+        ' ',
+        'you?',
+      ]);
+    });
+
+    test('should fallback to regular TextSpan when no callback', () {
+      final node = TappableTextNode(
+        text: 'Hello world',
+        onTapWord: null,
+      );
+
+      final span = node.build() as TextSpan;
+
+      // Should create a simple TextSpan without children
+      expect(span.children, isNull);
+      expect(span.toPlainText(), equals('Hello world'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Merges upstream/master into the fork, syncing 3 upstream commits
- Resolves merge conflict in `ListConfig` — keeps both the fork's word tap features (`onTapWord`, `highlightStyle`, `highlightedWord`) and upstream's new `richTextBuilder` field
- Preserves all local word-level tap and highlighting functionality

## Conflict resolution
`lib/widget/blocks/container/list.dart` — `ListConfig` had both sides adding new fields. Resolution keeps all fields: fork's `onTapWord`/`highlightStyle`/`highlightedWord` and upstream's `richTextBuilder`.

## Upstream commits merged
- `56131aa` fix: add wrapCode for code block node (#253)
- `20cc28a` feat: add RichTextBuilder for all configs (#252)
- `4a689e0` fix: extra space after a link (#251)

🤖 Generated with [Claude Code](https://claude.com/claude-code)